### PR TITLE
add background pattern to show transparent color option

### DIFF
--- a/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
+++ b/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
@@ -30,6 +30,27 @@
     margin: 0 10px 0 0;
 }
 
+.color-swatches button::after,
+.color-swatches button::before {
+  border-radius: 50%;
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.color-swatches button::after {
+  background-color: var(--color);
+}
+
+.color-swatches button::before {
+  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc), linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc);
+  background-position: 0 0, 6px 6px;
+  background-size: 12px 12px;
+}
+
 .color-swatches button:focus {
     outline: none;
 }

--- a/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
+++ b/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
@@ -42,7 +42,7 @@
 }
 
 .color-swatches button::after {
-  background-color: var(--color);
+  background: var(--color);
 }
 
 .color-swatches button::before {

--- a/src/templates/colourOption.twig
+++ b/src/templates/colourOption.twig
@@ -17,9 +17,9 @@
         style="
         {% switch colours | length %}
                 {% case 1 %}
-                    background: {{ value.color|parseRefs|raw }};
+                    --color: {{ value.color|parseRefs|raw }};
                 {% default %}
                     {% set percentage = 100 / colours | length %}
-                    background: linear-gradient(to bottom right, {% for colour in colours %}{{ colour|parseRefs|raw }} {{ percentage * loop.index0 }}%, {{ colour|parseRefs|raw }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
+                    --color: linear-gradient(to bottom right, {% for colour in colours %}{{ colour|parseRefs|raw }} {{ percentage * loop.index0 }}%, {{ colour|parseRefs|raw }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
         {% endswitch %}
 "></button>


### PR DESCRIPTION
Hi,

I often use `transparent` as a color option, and I need to visualize it in the control panel.

This pull request adds a checkerboard background to the button. If the color has no transparency, it will not be visible.

**Example**

```
[
  'label' => 'transparent',
  'color' => 'transparent',
  'default' => false,
],
[
  'label' => 'white',
  'color' => '#ffffff',
  'default' => true,
],
[
  'label' => 'light',
  'color' => '#9b9e98',
  'default' => false,
],
[
  'label' => 'dark',
  'color' => '#454544',
  'default' => false,
],
[
  'label' => 'accent',
  'color' => '#d9e100',
  'default' => false,
]

```

![cp-screenshot](https://user-images.githubusercontent.com/26137287/67291743-4c377580-f4e2-11e9-9bc1-b2f9a441a8c0.png)
